### PR TITLE
Update example app for Single Team Apps (remove OAuth)

### DIFF
--- a/example/README.rst
+++ b/example/README.rst
@@ -47,7 +47,7 @@ Visit your app's **Install App** page and click **Install App to Team**.
 
 Authorize your app
 
-.. image:: https://cloud.githubusercontent.com/assets/32463/24823911/a1d2f7c2-1bb8-11e7-96e2-6c71d4a9b66f.png
+.. image:: https://cloud.githubusercontent.com/assets/32463/24824091/d88e151a-1bba-11e7-8800-bc21c2ade036.png
    :width: 500 px
 
 

--- a/example/README.rst
+++ b/example/README.rst
@@ -43,22 +43,18 @@ Create a Slack app on https://api.slack.com/apps/
 Visit your app's **Install App** page and click **Install App to Team**.
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/24821248/5a0d5e8e-1ba2-11e7-8ca1-5461337a8046.png
-   :width: 500 px
 
 Authorize your app
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/24824091/d88e151a-1bba-11e7-8800-bc21c2ade036.png
-   :width: 500 px
-
 
 **🤖  Save your app's credentials**
 
 Once you've authorized your app, you'll be presented with your app's tokens.
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/24824016/c5f71628-1bb9-11e7-9662-a8919e5dc80f.png
-   :width: 500 px
 
-Copy your app's **Bot User OAuth Access Token** and set your app's environmental variables
+Copy your app's **Bot User OAuth Access Token** and add it to your python environmental variables
 
 .. code::
 
@@ -67,9 +63,8 @@ Copy your app's **Bot User OAuth Access Token** and set your app's environmental
 Next, go back to your app's **Basic Information** page
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20445302/61ddfc54-ad89-11e6-8523-245a60c875b0.png
-   :width: 500 px
 
-Save your app's **Client ID**, **Client Secret** and **Verification Token** to environmental variables
+Add your app's **Client ID**, **Client Secret** and **Verification Token** to your python environmental variables
 
 .. code::
 
@@ -117,10 +112,8 @@ Subscription setup
 Add your **Request URL** (your ngrok URL + ``/slack/events``) and subscribe your app to `message.channels` under bot events. **Save** and toggle **Enable Events** to `on`
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20366593/b40d14a4-ac00-11e6-8413-b473c16ef997.png
-   :width: 500 px
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20549612/e7ee2ed4-b0e2-11e6-8b9c-01ed08057c7c.png
-   :width: 500 px
 
 **🎉  Once your app has been installed and subscribed to Bot Events, you will begin receiving event data from Slack**
 
@@ -131,7 +124,6 @@ Invite your bot to a public channel, then say hi and your bot will respond
     hi @bot 👋
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/23047918/964defec-f467-11e6-87c3-9c7da11fc810.gif
-   :width: 500 px
 
 🤔  Support
 ------------

--- a/example/README.rst
+++ b/example/README.rst
@@ -1,12 +1,12 @@
 Example Slack events API bot
-============================
+=============================
 
 This example app shows how easy it is to implement the Slack Events API Adapter
 to receive Slack Events, extend it to handle the OAuth flow and respond to
 messages using Slack's Web API via python-slackclient.
 
 🤖  Setup and running the app
-------------
+------------------------------
 
 **Set up your Python environment:**
 
@@ -32,18 +32,30 @@ Create a Slack app on https://api.slack.com/apps/
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20549718/afdd98d0-b0e3-11e6-8d83-8ad7053deb80.png
 
-Add a **bot user** for your app
+**🤖  Add a bot user for your app**
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20371297/9044e2a0-ac18-11e6-8f25-3ffbd8a3bf58.png
 
-**🤖  Run the app:**
+**🤖  Install your app on your team**
 
-You'll need to have your server and ngrok running to complete your app's Event
-Subscription setup
+Visit your app's **Basic Information** page and go to **Install your app on your team**, then follow the instructions to install the app.
+
+.. image:: https://cloud.githubusercontent.com/assets/32463/24821248/5a0d5e8e-1ba2-11e7-8ca1-5461337a8046.png
+
+**🤖  Save your app's credentials**
+
+Go to your app's **Basic Information** page and save your app's **Client ID**, **Client Secret** and **Verification Token** to environmental variables
+
+.. image:: https://cloud.githubusercontent.com/assets/32463/20445302/61ddfc54-ad89-11e6-8523-245a60c875b0.png
+
+**🤖  Assign your app's credentials to environment variables and run your app:**
 
 .. code::
 
-  python example.py
+  export SLACK_CLIENT_ID=xxxxxxxxxxx.xxxxxxxxxxxxx
+  export SLACK_CLIENT_SECRET=XxxxXxxXXXxxXxxXX
+  export SLACK_VERIFICATION_TOKEN=xxxxxxxxXxxXxxXxXXXxxXxxx
+  export SLACK_BOT_TOKEN=xxxXXxxXXxXXxXXXXxxxX.xXxxxXxxxx
 
 **🤖  Start ngrok**
 
@@ -71,6 +83,15 @@ Run ngrok and copy the **HTTPS** URL
   Forwarding http://h7465j.ngrok.io -> localhost:9292
   Forwarding https://h7465j.ngrok.io -> localhost:9292
 
+**🤖  Run the app:**
+
+You'll need to have your server and ngrok running to complete your app's Event
+Subscription setup
+
+.. code::
+
+  python example.py
+
 **🤖  Subscribe your app to events**
 
 Add your **Request URL** (your ngrok URL + ``/slack/events``) and subscribe your app to `message.channels` under bot events. **Save** and toggle **Enable Events** to `on`
@@ -79,40 +100,7 @@ Add your **Request URL** (your ngrok URL + ``/slack/events``) and subscribe your
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20549612/e7ee2ed4-b0e2-11e6-8b9c-01ed08057c7c.png
 
-**🤖  Save your app's credentials**
-
-Go to your app's **Basic Information** page and save your app's **Client ID**, **Client Secret** and **Verification Token** to environmental variables
-
-.. image:: https://cloud.githubusercontent.com/assets/32463/20445302/61ddfc54-ad89-11e6-8523-245a60c875b0.png
-
-**🤖  Add your OAuth URL**
-
-Add your OAuth redirect URL (your ngrok URL + ``/auth/slack/callback``)
-
-.. image:: https://cloud.githubusercontent.com/assets/32463/20543629/63e41a26-b0bb-11e6-8eee-90c6f4f1dbb1.png
-
-**🤖  Assign your app's credentials to environment variables:**
-
-.. code::
-
-  export SLACK_CLIENT_ID=xxxxxxxxxxx.xxxxxxxxxxxxx
-  export SLACK_CLIENT_SECRET=XxxxXxxXXXxxXxxXX
-  export SLACK_VERIFICATION_TOKEN=xxxxxxxxXxxXxxXxXXXxxXxxx
-
-**🤖  Restart your app to load it's credentials**
-
-.. code::
-
-  python example.py
-
-
-**🤖  Auth your app**
-
-Go to your ngrok URL (e.g. https://myapp12.ngrok.com/) and auth your app.
-
-.. image:: https://cloud.githubusercontent.com/assets/32463/20575277/789c0c5a-b16d-11e6-86fd-e30c3a0d2e61.gif
-
-**🎉 Once your app has been authorized, you will begin receiving Slack events**
+**🎉  Once your app has been installed and subscribed to Bot Events, you will begin receiving event data from Slack**
 
 **👋  Interact with your bot:**
 
@@ -123,15 +111,12 @@ Invite your bot to a public channel, then say hi and your bot will respond
 .. image:: https://cloud.githubusercontent.com/assets/32463/23047918/964defec-f467-11e6-87c3-9c7da11fc810.gif
 
 🤔  Support
--------
+------------
 
 Need help? Join `Bot Developer Hangout`_ and talk to us in `#slack-api`_.
 
 You can also `create an Issue`_ right here on GitHub.
 
-.. _Events API: https://api.slack.com/events-api
-.. _create a Slack App: https://api.slack.com/apps/new
-.. _Event Subscriptions: https://api.slack.com/events-api#subscriptions
 .. _Bot Developer Hangout: http://dev4slack.xoxco.com/
 .. _#slack-api: https://dev4slack.slack.com/messages/slack-api/
 .. _create an Issue: https://github.com/slackapi/node-slack-events-api/issues/new

--- a/example/README.rst
+++ b/example/README.rst
@@ -31,31 +31,51 @@ See `virtualenv`_ docs for more info.
 Create a Slack app on https://api.slack.com/apps/
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20549718/afdd98d0-b0e3-11e6-8d83-8ad7053deb80.png
+   :width: 500 px
 
-**🤖  Add a bot user for your app**
+**🤖  Add a bot user to your app**
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20371297/9044e2a0-ac18-11e6-8f25-3ffbd8a3bf58.png
+   :width: 500 px
 
 **🤖  Install your app on your team**
 
-Visit your app's **Basic Information** page and go to **Install your app on your team**, then follow the instructions to install the app.
+Visit your app's **Install App** page and click **Install App to Team**.
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/24821248/5a0d5e8e-1ba2-11e7-8ca1-5461337a8046.png
+   :width: 500 px
+
+Authorize your app
+
+.. image:: https://cloud.githubusercontent.com/assets/32463/24823911/a1d2f7c2-1bb8-11e7-96e2-6c71d4a9b66f.png
+   :width: 500 px
+
 
 **🤖  Save your app's credentials**
 
-Go to your app's **Basic Information** page and save your app's **Client ID**, **Client Secret** and **Verification Token** to environmental variables
+Once you've authorized your app, you'll be presented with your app's tokens.
+
+.. image:: https://cloud.githubusercontent.com/assets/32463/24824016/c5f71628-1bb9-11e7-9662-a8919e5dc80f.png
+   :width: 500 px
+
+Copy your app's **Bot User OAuth Access Token** and set your app's environmental variables
+
+.. code::
+
+  export SLACK_BOT_TOKEN=xxxXXxxXXxXXxXXXXxxxX.xXxxxXxxxx
+
+Next, go back to your app's **Basic Information** page
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20445302/61ddfc54-ad89-11e6-8523-245a60c875b0.png
+   :width: 500 px
 
-**🤖  Assign your app's credentials to environment variables and run your app:**
+Save your app's **Client ID**, **Client Secret** and **Verification Token** to environmental variables
 
 .. code::
 
   export SLACK_CLIENT_ID=xxxxxxxxxxx.xxxxxxxxxxxxx
   export SLACK_CLIENT_SECRET=XxxxXxxXXXxxXxxXX
   export SLACK_VERIFICATION_TOKEN=xxxxxxxxXxxXxxXxXXXxxXxxx
-  export SLACK_BOT_TOKEN=xxxXXxxXXxXXxXXXXxxxX.xXxxxXxxxx
 
 **🤖  Start ngrok**
 
@@ -97,8 +117,10 @@ Subscription setup
 Add your **Request URL** (your ngrok URL + ``/slack/events``) and subscribe your app to `message.channels` under bot events. **Save** and toggle **Enable Events** to `on`
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20366593/b40d14a4-ac00-11e6-8413-b473c16ef997.png
+   :width: 500 px
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/20549612/e7ee2ed4-b0e2-11e6-8b9c-01ed08057c7c.png
+   :width: 500 px
 
 **🎉  Once your app has been installed and subscribed to Bot Events, you will begin receiving event data from Slack**
 
@@ -109,6 +131,7 @@ Invite your bot to a public channel, then say hi and your bot will respond
     hi @bot 👋
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/23047918/964defec-f467-11e6-87c3-9c7da11fc810.gif
+   :width: 500 px
 
 🤔  Support
 ------------

--- a/example/README.rst
+++ b/example/README.rst
@@ -30,29 +30,27 @@ See `virtualenv`_ docs for more info.
 
 Create a Slack app on https://api.slack.com/apps/
 
-.. image:: https://cloud.githubusercontent.com/assets/32463/20549718/afdd98d0-b0e3-11e6-8d83-8ad7053deb80.png
-   :width: 500 px
+.. image:: https://cloud.githubusercontent.com/assets/32463/24877733/32979776-1de5-11e7-87d4-b5dc9e3e7973.png
 
 **🤖  Add a bot user to your app**
 
-.. image:: https://cloud.githubusercontent.com/assets/32463/20371297/9044e2a0-ac18-11e6-8f25-3ffbd8a3bf58.png
-   :width: 500 px
+.. image:: https://cloud.githubusercontent.com/assets/32463/24877750/47a16034-1de5-11e7-989b-2a90b9d8e7e3.png
 
 **🤖  Install your app on your team**
 
 Visit your app's **Install App** page and click **Install App to Team**.
 
-.. image:: https://cloud.githubusercontent.com/assets/32463/24821248/5a0d5e8e-1ba2-11e7-8ca1-5461337a8046.png
+.. image:: https://cloud.githubusercontent.com/assets/32463/24877770/61804c36-1de5-11e7-91ef-5cf2e0845729.png
 
 Authorize your app
 
-.. image:: https://cloud.githubusercontent.com/assets/32463/24824091/d88e151a-1bba-11e7-8800-bc21c2ade036.png
+.. image:: https://cloud.githubusercontent.com/assets/32463/24877792/774ed94c-1de5-11e7-8857-ac8d662c5b27.png
 
 **🤖  Save your app's credentials**
 
 Once you've authorized your app, you'll be presented with your app's tokens.
 
-.. image:: https://cloud.githubusercontent.com/assets/32463/24824016/c5f71628-1bb9-11e7-9662-a8919e5dc80f.png
+.. image:: https://cloud.githubusercontent.com/assets/32463/24877652/d8eebbb4-1de4-11e7-8f75-2cfb1e9d45ee.png
 
 Copy your app's **Bot User OAuth Access Token** and add it to your python environmental variables
 
@@ -62,7 +60,7 @@ Copy your app's **Bot User OAuth Access Token** and add it to your python enviro
 
 Next, go back to your app's **Basic Information** page
 
-.. image:: https://cloud.githubusercontent.com/assets/32463/20445302/61ddfc54-ad89-11e6-8523-245a60c875b0.png
+.. image:: https://cloud.githubusercontent.com/assets/32463/24877833/950dd53c-1de5-11e7-984f-deb26e8b9482.png
 
 Add your app's **Client ID**, **Client Secret** and **Verification Token** to your python environmental variables
 
@@ -111,9 +109,9 @@ Subscription setup
 
 Add your **Request URL** (your ngrok URL + ``/slack/events``) and subscribe your app to `message.channels` under bot events. **Save** and toggle **Enable Events** to `on`
 
-.. image:: https://cloud.githubusercontent.com/assets/32463/20366593/b40d14a4-ac00-11e6-8413-b473c16ef997.png
+.. image:: https://cloud.githubusercontent.com/assets/32463/24877867/b39d4384-1de5-11e7-9676-9e47ea7db4e7.png
 
-.. image:: https://cloud.githubusercontent.com/assets/32463/20549612/e7ee2ed4-b0e2-11e6-8b9c-01ed08057c7c.png
+.. image:: https://cloud.githubusercontent.com/assets/32463/24877931/e119181a-1de5-11e7-8b0c-fcbc3419bad7.png
 
 **🎉  Once your app has been installed and subscribed to Bot Events, you will begin receiving event data from Slack**
 

--- a/example/example.py
+++ b/example/example.py
@@ -11,80 +11,35 @@ CLIENTS = {}
 SLACK_VERIFICATION_TOKEN = os.environ["SLACK_VERIFICATION_TOKEN"]
 slack_events_adapter = SlackEventAdapter(SLACK_VERIFICATION_TOKEN, "/slack/events")
 
-# Since SlackEventAdapter uses a standard Flask server, we can extend it to handle OAuth
-# by simply adding a couple more route handlers.
-
 # Slack App credentials for OAuth
 SLACK_CLIENT_ID = os.environ["SLACK_CLIENT_ID"]
 SLACK_CLIENT_SECRET = os.environ["SLACK_CLIENT_SECRET"]
+SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
+
+# Create a SlackClient for your bot to use for Web API requests
+CLIENT = SlackClient(SLACK_BOT_TOKEN)
 
 
-# This route renders the installation page with 'Add to Slack' button.
-@slack_events_adapter.server.route("/", methods=["GET"])
-def pre_install():
-    add_to_slack = """
-        <a href="https://slack.com/oauth/authorize?scope=bot&client_id=%s">
-            <img alt="Add to Slack" src="https://platform.slack-edge.com/img/add_to_slack.png"/>
-        </a>
-    """ % SLACK_CLIENT_ID
-    return add_to_slack
-
-
-# This route is called by Slack after the user installs our app. It will
-# exchange the temporary authorization code Slack sends for an OAuth token
-# which we'll save on the bot object to use later.
-# To let the user know what's happened it will also render a thank you page.
-@slack_events_adapter.server.route("/auth/slack/callback", methods=["GET"])
-def thanks():
-
-    # Get the OAuth code to pass into the token request
-    auth_code = request.args.get('code')
-
-    # Create a temporary Slack client to make the OAuth request.
-    # This client doesn't need a token.
-    slack_client = SlackClient("")
-
-    # Ask Slack for a bot token, using the auth code we received
-    auth_response = slack_client.api_call(
-        "oauth.access",
-        client_id=SLACK_CLIENT_ID,
-        client_secret=SLACK_CLIENT_SECRET,
-        code=auth_code
-    )
-
-    # Grab the user's team info and token from the OAuth response
-    team_id = auth_response.get("team_id")
-    team_name = auth_response.get("team_name")
-    bot_token = auth_response["bot"].get("bot_access_token")
-
-    # Create a SlackClient for your bot to use for Web API requests
-    CLIENTS[team_id] = SlackClient(bot_token)
-    return "Your app has been installed on <b>%s</b>" % team_name
-
-
-# Now we'll set up some event listeners for our app to process and respond to
 # Example responder to greetings
 @slack_events_adapter.on("message")
 def handle_message(event_data):
-    team_id = event_data["team_id"]
     message = event_data["event"]
+    # If the incoming message contains "hi", then respond with a "Hello" message
     if message.get("subtype") is None and "hi" in message.get('text'):
         channel = message["channel"]
         message = "Hello <@%s>! :tada:" % message["user"]
-        CLIENTS[team_id].api_call("chat.postMessage", channel=channel, text=message)
+        CLIENT.api_call("chat.postMessage", channel=channel, text=message)
 
 
 # Example reaction emoji echo
 @slack_events_adapter.on("reaction_added")
 def reaction_added(event_data):
-    team_id = event_data["team_id"]
     event = event_data["event"]
     emoji = event["reaction"]
     channel = event["item"]["channel"]
     text = ":%s:" % emoji
-    CLIENTS[team_id].api_call("chat.postMessage", channel=channel, text=text)
+    CLIENT.api_call("chat.postMessage", channel=channel, text=text)
 
-
-# Once we have our addon routes and event listeners configured, we can start the
+# Once we have our event listeners configured, we can start the
 # Flask server with the default `/events` endpoint on port 3000
 slack_events_adapter.start(port=3000)


### PR DESCRIPTION
###  Summary

Since this example app was written, we've launched Single Team Apps which simplifies the initial development setup process quite a bit. This change removes OAuth from the example app in order to make the README and code itself easier to read.

### Requirements (place an `x` in each `[ ]`)

✅ I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
✅ I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
