### PR TITLE
[MINOR] Decode byte stream into utf-8

### DIFF
--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -14,7 +14,7 @@ class SlackServer(Flask):
                 return make_response("These are not the slackbots you're looking for.", 404)
 
             # Parse the request payload into JSON
-            event_data = json.loads(request.data)
+            event_data = json.loads(request.data.decode('utf-8'))
 
             # Echo the URL verification challenge code
             if "challenge" in event_data:


### PR DESCRIPTION
###  Summary
Fixes #17

The Slack challenge token response is received as bytestream not str. This breaks in Python 3.x. As a fix, we simply decode the stream to string, and everything works as expected

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
