### PR TITLE
added health endpoint and associated tests

### DIFF
--- a/slackeventsapi/__init__.py
+++ b/slackeventsapi/__init__.py
@@ -5,10 +5,17 @@ from .server import SlackServer
 class SlackEventAdapter(EventEmitter):
     # Initialize the Slack event server
     # If no endpoint is provided, default to listening on '/slack/events'
-    def __init__(self, verification_token, endpoint="/slack/events"):
+    # **kwargs:
+    #   If no health_endpoint is provided, default defined as '/health' in
+    #   server.py
+    #
+    #   If no health_callback is provided, default is 200 healthy in
+    #   server.py. A provided health_callback function must require no
+    #   arguments and return a Flask-compatible response.
+    def __init__(self, verification_token, endpoint="/slack/events", **kwargs):
         EventEmitter.__init__(self)
         self.verification_token = verification_token
-        self.server = SlackServer(verification_token, endpoint, self)
+        self.server = SlackServer(verification_token, endpoint, self, **kwargs)
 
     def start(self, host='127.0.0.1', port=None, debug=False, **kwargs):
         self.server.run(host=host, port=port, debug=debug, **kwargs)

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -3,7 +3,12 @@ import json
 
 
 class SlackServer(Flask):
-    def __init__(self, verification_token, endpoint, emitter, health_endpoint='/health', health_callback=None):
+    def __init__(self,
+                 verification_token,
+                 endpoint,
+                 emitter,
+                 health_endpoint='/health',
+                 health_callback=None):
         Flask.__init__(self, __name__)
         self._health_callback = health_callback
         self.verification_token = verification_token

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -3,8 +3,9 @@ import json
 
 
 class SlackServer(Flask):
-    def __init__(self, verification_token, endpoint, emitter):
+    def __init__(self, verification_token, endpoint, emitter, health_endpoint='/health', health_callback=None):
         Flask.__init__(self, __name__)
+        self._health_callback = health_callback
         self.verification_token = verification_token
 
         @self.route(endpoint, methods=['GET', 'POST'])
@@ -33,3 +34,9 @@ class SlackServer(Flask):
                 event_type = event_data["event"]["type"]
                 emitter.emit(event_type, event_data)
                 return make_response("", 200)
+
+        @self.route(health_endpoint, methods=['GET'])
+        def health():
+            if self._health_callback is not None:
+                return health_callback()
+            return make_response("healthy", 200)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,3 +25,20 @@ def test_valid_event(client):
         data=data,
         content_type='application/json')
     assert res.status_code == 200
+
+@pytest.mark.health_ok
+def test_default_health_endpoint(client):
+    res = client.get('/health')
+    assert res.status_code == 200
+
+@pytest.mark.health_ok
+@pytest.mark.health_custom
+def test_custom_ok_health_endpoint(client):
+    res = client.get('/health_custom')
+    assert res.status_code == 200
+
+@pytest.mark.health_unavailable
+@pytest.mark.health_custom
+def test_custom_unavailable_health_endpoint(client):
+    res = client.get('/health_custom')
+    assert res.status_code == 503


### PR DESCRIPTION
###  Summary

The goal of this PR is to add a flexible heath endpoint to make it easy for this service to run inside of a platform like Kubernetes. Further details in: #24 


### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
