### PR TITLE
Improve security by adding request signing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 dist: trusty
 language: python
 python:
+  - "2.7.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Create a Slack Event Adapter for receiving actions via the Events API
   from slackeventsapi import SlackEventAdapter
 
 
-  slack_events_adapter = SlackEventAdapter(SLACK_VERIFICATION_TOKEN, endpoint="/slack/events")
+  slack_events_adapter = SlackEventAdapter(SLACK_VERIFICATION_TOKEN, endpoint="/slack_events")
 
 
   # Create an event listener for "reaction_added" events and print the emoji name

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ user has authorized your app.
 
 .. code:: python
 
-  SLACK_VERIFICATION_TOKEN = os.environ["SLACK_VERIFICATION_TOKEN"]
+  SLACK_SIGNING_SECRET = os.environ["SLACK_SIGNING_SECRET"]
 
 Create a Slack Event Adapter for receiving actions via the Events API
 -----------------------------------------------------------------------
@@ -83,7 +83,7 @@ Create a Slack Event Adapter for receiving actions via the Events API
   from slackeventsapi import SlackEventAdapter
 
 
-  slack_events_adapter = SlackEventAdapter(SLACK_VERIFICATION_TOKEN, endpoint="/slack_events")
+  slack_events_adapter = SlackEventAdapter(SLACK_SIGNING_SECRET, endpoint="/slack/events")
 
 
   # Create an event listener for "reaction_added" events and print the emoji name
@@ -118,7 +118,7 @@ Create a Slack Event Adapter for receiving actions via the Events API
 
   # Bind the Events API route to your existing Flask app by passing the server
   # instance as the last param, or with `server=app`.
-  slack_events_adapter = SlackEventAdapter(SLACK_VERIFICATION_TOKEN, "/slack/events", app)
+  slack_events_adapter = SlackEventAdapter(SLACK_SIGNING_SECRET, "/slack/events", app)
 
 
   # Create an event listener for "reaction_added" events and print the emoji name

--- a/example/README.rst
+++ b/example/README.rst
@@ -75,13 +75,7 @@ Next, go back to your app's **Basic Information** page
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/24877833/950dd53c-1de5-11e7-984f-deb26e8b9482.png
 
-Add your app's **Verification Token** to your python environmental variables
-
-.. code::
-
-  export SLACK_VERIFICATION_TOKEN=xxxxxxxxXxxXxxXxXXXxxXxxx
-
-Add your app's **Signing Secret** to your python environmental variables
+Add your app's **Singing Secret** to your python environmental variables
 
 .. code::
 

--- a/example/README.rst
+++ b/example/README.rst
@@ -81,6 +81,12 @@ Add your app's **Verification Token** to your python environmental variables
 
   export SLACK_VERIFICATION_TOKEN=xxxxxxxxXxxXxxXxXXXxxXxxx
 
+Add your app's **Signing Secret** to your python environmental variables
+
+.. code::
+
+  export SLACK_SIGNING_SECRET=xxxxxxxxXxxXxxXxXXXxxXxxx
+
 
 **🤖  Start ngrok**
 

--- a/example/README.rst
+++ b/example/README.rst
@@ -75,7 +75,7 @@ Next, go back to your app's **Basic Information** page
 
 .. image:: https://cloud.githubusercontent.com/assets/32463/24877833/950dd53c-1de5-11e7-984f-deb26e8b9482.png
 
-Add your app's **Singing Secret** to your python environmental variables
+Add your app's **Signing Secret** to your python environmental variables
 
 .. code::
 

--- a/slackeventsapi/__init__.py
+++ b/slackeventsapi/__init__.py
@@ -5,10 +5,10 @@ from .server import SlackServer
 class SlackEventAdapter(EventEmitter):
     # Initialize the Slack event server
     # If no endpoint is provided, default to listening on '/slack/events'
-    def __init__(self, verification_token, endpoint="/slack/events", server=None):
+    def __init__(self, signing_secret, endpoint="/slack/events", server=None, **kwargs):
         EventEmitter.__init__(self)
-        self.verification_token = verification_token
-        self.server = SlackServer(verification_token, endpoint, self, server)
+        self.signing_secret = signing_secret
+        self.server = SlackServer(signing_secret, endpoint, self, server, **kwargs)
 
     def start(self, host='127.0.0.1', port=None, debug=False, **kwargs):
         """

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -66,7 +66,7 @@ class SlackServer(Flask):
             if abs(time() - int(req_timestamp)) > 60 * 5:
                 slack_exception = Exception('Invalid request timestamp')
                 self.emitter.emit('error', slack_exception)
-                return make_response("", 200)
+                return make_response("", 403)
 
             # Verify the request signature using the app's signing secret
             # emit an error if the signature can't be verified

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -46,7 +46,11 @@ class SlackServer(Flask):
 
     def verify_signature(self, timestamp, signature):
         req = str.encode('v0:' + str(timestamp) + ':') + request.data
-        request_hash = 'v0='+hmac.new(str.encode(self.signing_secret), req, hashlib.sha256).hexdigest()
+        request_hash = 'v0='+hmac.new(
+            str.encode(self.signing_secret),
+            req, hashlib.sha256
+        ).hexdigest()
+
         return hmac.compare_digest(request_hash, str(signature))
 
     def bind_route(self, server):

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -60,15 +60,6 @@ class SlackServer(Flask):
             if request.method == 'GET':
                 return make_response("These are not the slackbots you're looking for.", 404)
 
-            # Parse the request payload into JSON
-            event_data = json.loads(request.data.decode('utf-8'))
-
-            # Echo the URL verification challenge code back to Slack
-            if "challenge" in event_data:
-                return make_response(
-                    event_data.get("challenge"), 200, {"content_type": "application/json"}
-                )
-
             # Each request comes with request timestamp and request signature
             # emit an error if the timestamp is out of range
             req_timestamp = request.headers.get('X-Slack-Request-Timestamp')
@@ -84,6 +75,15 @@ class SlackServer(Flask):
                 slack_exception = Exception('Invalid request signature')
                 self.emitter.emit('error', slack_exception)
                 return make_response("", 403)
+
+            # Parse the request payload into JSON
+            event_data = json.loads(request.data.decode('utf-8'))
+
+            # Echo the URL verification challenge code back to Slack
+            if "challenge" in event_data:
+                return make_response(
+                    event_data.get("challenge"), 200, {"content_type": "application/json"}
+                )
 
             # Parse the Event payload and emit the event to the event listener
             if "event" in event_data:

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -44,7 +44,6 @@ class SlackServer(Flask):
 
         return " ".join(ua_string)
 
-
     def verify_signature(self, timestamp, signature):
         # Verify the request signature of the request sent from Slack
         # Generate a new hash using the app's signing secret and request data
@@ -73,7 +72,6 @@ class SlackServer(Flask):
                 for x, y in zip(request_hash, signature):
                     result |= ord(x) ^ ord(y)
             return result == 0
-
 
     def bind_route(self, server):
         @server.route(self.endpoint, methods=['GET', 'POST'])

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -51,7 +51,7 @@ class SlackServer(Flask):
         # Compare the generated hash and incoming request signature
         # Python 2.7.6 doesn't support compare_digest
         # It's recommended to use Python 2.7.7+
-        # See https://docs.python.org/2/whatsnew/2.7.html#pep-466-network-security-enhancements-for-python-2-7
+        # noqa See https://docs.python.org/2/whatsnew/2.7.html#pep-466-network-security-enhancements-for-python-2-7
         if hasattr(hmac, "compare_digest"):
             req = str.encode('v0:' + str(timestamp) + ':') + request.data
             request_hash = 'v0=' + hmac.new(

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -64,7 +64,7 @@ class SlackServer(Flask):
             # emit an error if the timestamp is out of range
             req_timestamp = request.headers.get('X-Slack-Request-Timestamp')
             if abs(time() - int(req_timestamp)) > 60 * 5:
-                slack_exception = Exception('Invalid request timestamp')
+                slack_exception = SlackEventAdapterException('Invalid request timestamp')
                 self.emitter.emit('error', slack_exception)
                 return make_response("", 403)
 
@@ -72,7 +72,7 @@ class SlackServer(Flask):
             # emit an error if the signature can't be verified
             req_signature = request.headers.get('X-Slack-Signature')
             if not self.verify_signature(req_timestamp, req_signature):
-                slack_exception = Exception('Invalid request signature')
+                slack_exception = SlackEventAdapterException('Invalid request signature')
                 self.emitter.emit('error', slack_exception)
                 return make_response("", 403)
 
@@ -92,3 +92,14 @@ class SlackServer(Flask):
                 response = make_response("", 200)
                 response.headers['X-Slack-Powered-By'] = self.package_info
                 return response
+
+
+class SlackEventAdapterException(Exception):
+    """
+    Base exception for all errors raised by the SlackClient library
+    """
+    def __init__(self, msg=None):
+        if msg is None:
+            # default error message
+            msg = "An error occurred in the SlackEventsApiAdapter library"
+        super(SlackEventAdapterException, self).__init__(msg)

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -72,16 +72,18 @@ class SlackServer(Flask):
             # Each request comes with request timestamp and request signature
             # emit an error if the timestamp is out of range
             req_timestamp = request.headers.get('X-Slack-Request-Timestamp')
-            if abs(time() - int(req_timestamp)) > 60 * 10:
-                self.emitter.emit('error', Exception('Request timestamp invalid'))
+            if abs(time() - int(req_timestamp)) > 60 * 5:
+                slack_exception = Exception('Invalid request timestamp')
+                self.emitter.emit('error', slack_exception)
                 return make_response("", 200)
 
             # Verify the request signature using the app's signing secret
             # emit an error if the signature can't be verified
             req_signature = request.headers.get('X-Slack-Signature')
             if not self.verify_signature(req_timestamp, req_signature):
-                self.emitter.emit('error', Exception('invalid request signature'))
-                return make_response("", 200)
+                slack_exception = Exception('Invalid request signature')
+                self.emitter.emit('error', slack_exception)
+                return make_response("", 403)
 
             # Parse the Event payload and emit the event to the event listener
             if "event" in event_data:

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -9,7 +9,7 @@ from .version import __version__
 
 
 class SlackServer(Flask):
-    def __init__(self, signing_secret, endpoint, emitter, server, **kwargs):
+    def __init__(self, signing_secret, endpoint, emitter, server):
         self.signing_secret = signing_secret
         self.emitter = emitter
         self.endpoint = endpoint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,17 @@
-import pytest
 import json
+import hashlib
+import hmac
+import pytest
 from slackeventsapi import SlackEventAdapter
+
+
+def create_signature(secret, timestamp, data):
+    req = str.encode('v0:' + str(timestamp) + ':') + str.encode(data)
+    request_signature= 'v0='+hmac.new(
+        str.encode(secret),
+        req, hashlib.sha256
+    ).hexdigest()
+    return request_signature
 
 
 def load_event_fixture(event, as_string=True):
@@ -23,7 +34,8 @@ def pytest_namespace():
     return {
         'reaction_event_fixture': load_event_fixture('reaction_added'),
         'url_challenge_fixture': load_event_fixture('url_challenge'),
-        'bad_token_fixture': event_with_bad_token()
+        'bad_token_fixture': event_with_bad_token(),
+        'create_signature': create_signature
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,6 @@ def pytest_namespace():
 
 @pytest.fixture
 def app():
-    adapter = SlackEventAdapter("vFO9LARnLI7GflLR8tGqHgdy")
+    adapter = SlackEventAdapter("SIGNING_SECRET")
     app = adapter.server
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,4 +43,5 @@ def pytest_namespace():
 def app():
     adapter = SlackEventAdapter("SIGNING_SECRET")
     app = adapter.server
+    app.testing = True
     return app

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,29 +1,18 @@
-import hmac
-import hashlib
 import time
 import pytest
 from slackeventsapi import SlackEventAdapter
 
 ADAPTER = SlackEventAdapter('SIGNING_SECRET')
 
-def create_signature(secret, timestamp, data):
-    req = str.encode('v0:' + str(timestamp) + ':') + data
-    request_signature= 'v0='+hmac.new(
-        str.encode(secret),
-        req, hashlib.sha256
-    ).hexdigest()
-    return request_signature
-
-
 def test_event_emission(client):
     # Events should trigger an event
-    data = pytest.reaction_event_fixture
-    timestamp = int(time.time())
-    signature =create_signature(ADAPTER.signing_secret, timestamp, data)
-
     @ADAPTER.on('reaction_added')
     def event_handler(event):
         assert event["reaction"] == 'grinning'
+
+    data = pytest.reaction_event_fixture
+    timestamp = int(time.time())
+    signature = pytest.create_signature(ADAPTER.signing_secret, timestamp, data)
 
     res = client.post(
         '/slack/events',

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,12 +1,25 @@
+import hmac
+import hashlib
+import time
 import pytest
 from slackeventsapi import SlackEventAdapter
 
-ADAPTER = SlackEventAdapter('vFO9LARnLI7GflLR8tGqHgdy')
+ADAPTER = SlackEventAdapter('SIGNING_SECRET')
+
+def create_signature(secret, timestamp, data):
+    req = str.encode('v0:' + str(timestamp) + ':') + data
+    request_signature= 'v0='+hmac.new(
+        str.encode(secret),
+        req, hashlib.sha256
+    ).hexdigest()
+    return request_signature
 
 
 def test_event_emission(client):
     # Events should trigger an event
     data = pytest.reaction_event_fixture
+    timestamp = int(time.time())
+    signature =create_signature(ADAPTER.signing_secret, timestamp, data)
 
     @ADAPTER.on('reaction_added')
     def event_handler(event):
@@ -15,7 +28,11 @@ def test_event_emission(client):
     res = client.post(
         '/slack/events',
         data=data,
-        content_type='application/json'
+        content_type='application/json',
+        headers={
+            'X-Slack-Request-Timestamp': timestamp,
+            'X-Slack-Signature': signature
+        }
     )
 
     assert res.status_code == 200

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -94,7 +94,9 @@ def test_invalid_request_timestamp(client):
 def test_compare_digest_fallback(client, monkeypatch):
     # Verify [package metadata header is set
     slack_adapter = SlackEventAdapter("SIGNING_SECRET")
-    monkeypatch.delattr(hmac, 'compare_digest')
+
+    if hasattr(hmac, "compare_digest"):
+        monkeypatch.delattr(hmac, 'compare_digest')
 
     data = pytest.reaction_event_fixture
     timestamp = int(time.time())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@ import json
 from flask import Flask
 import pytest
 import sys
+import hmac
 import time
 from slackeventsapi import SlackEventAdapter
 from slackeventsapi.server import SlackEventAdapterException
@@ -68,6 +69,50 @@ def test_invalid_request_signature(client):
     assert str(excinfo.value) == 'Invalid request signature'
 
 
+def test_invalid_request_timestamp(client):
+    # Verify [package metadata header is set
+    slack_adapter = SlackEventAdapter("SIGNING_SECRET")
+
+    data = pytest.reaction_event_fixture
+    timestamp = int(time.time()+1000)
+    signature = "bad timestamp"
+
+    with pytest.raises(SlackEventAdapterException) as excinfo:
+        res = client.post(
+            '/slack/events',
+            data=data,
+            content_type='application/json',
+            headers={
+                'X-Slack-Request-Timestamp': timestamp,
+                'X-Slack-Signature': signature
+            }
+        )
+
+    assert str(excinfo.value) == 'Invalid request timestamp'
+
+
+def test_compare_digest_fallback(client, monkeypatch):
+    # Verify [package metadata header is set
+    slack_adapter = SlackEventAdapter("SIGNING_SECRET")
+    monkeypatch.delattr(hmac, 'compare_digest')
+
+    data = pytest.reaction_event_fixture
+    timestamp = int(time.time())
+    signature =pytest.create_signature(slack_adapter.signing_secret, timestamp, data)
+
+    res = client.post(
+        '/slack/events',
+        data=data,
+        content_type='application/json',
+        headers={
+            'X-Slack-Request-Timestamp': timestamp,
+            'X-Slack-Signature': signature
+        }
+    )
+
+    assert res.status_code == 200
+
+
 def test_version_header(client):
     # Verify [package metadata header is set
     slack_adapter = SlackEventAdapter("SIGNING_SECRET")
@@ -97,3 +142,10 @@ def test_server_start(mocker):
     mocker.spy(slack_events_adapter, 'server')
     slack_events_adapter.start(port=3000)
     slack_events_adapter.server.run.assert_called_once_with(debug=False, host='127.0.0.1', port=3000)
+
+
+def test_default_exception_msg(mocker):
+    with pytest.raises(SlackEventAdapterException) as excinfo:
+        raise SlackEventAdapterException
+
+    assert str(excinfo.value) == 'An error occurred in the SlackEventsApiAdapter library'

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ import pytest
 import sys
 import time
 from slackeventsapi import SlackEventAdapter
+from slackeventsapi.server import SlackEventAdapterException
 from slackeventsapi.version import __version__
 
 
@@ -53,7 +54,7 @@ def test_invalid_request_signature(client):
     timestamp = int(time.time())
     signature = "bad signature"
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(SlackEventAdapterException) as excinfo:
         res = client.post(
             '/slack/events',
             data=data,
@@ -64,7 +65,7 @@ def test_invalid_request_signature(client):
             }
         )
 
-        assert res.status_code == 404
+    assert str(excinfo.value) == 'Invalid request signature'
 
 
 def test_version_header(client):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,21 +1,10 @@
 import json
 from flask import Flask
-import hashlib
-import hmac
 import pytest
 import sys
 import time
 from slackeventsapi import SlackEventAdapter
 from slackeventsapi.version import __version__
-
-
-def create_signature(secret, timestamp, data):
-    req = str.encode('v0:' + str(timestamp) + ':') + data
-    request_signature= 'v0='+hmac.new(
-        str.encode(secret),
-        req, hashlib.sha256
-    ).hexdigest()
-    return request_signature
 
 
 def test_existing_flask():
@@ -41,7 +30,7 @@ def test_url_challenge(client):
     slack_adapter = SlackEventAdapter("SIGNING_SECRET")
     data = pytest.url_challenge_fixture
     timestamp = int(time.time())
-    signature = create_signature(slack_adapter.signing_secret, timestamp, data)
+    signature = pytest.create_signature(slack_adapter.signing_secret, timestamp, data)
 
     res = client.post(
         '/slack/events',
@@ -85,7 +74,7 @@ def test_version_header(client):
 
     data = pytest.reaction_event_fixture
     timestamp = int(time.time())
-    signature =create_signature(slack_adapter.signing_secret, timestamp, data)
+    signature =pytest.create_signature(slack_adapter.signing_secret, timestamp, data)
 
     res = client.post(
         '/slack/events',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 ; for quality analysis, use `tox -e flake8` or just `flake8 slackeventsapi`
 ; to build the docs, use `tox -e docs`
 envlist=
-    py{27,33,34,35,36},
+    py{276,27,33,34,35,36},
     flake8,
     docs
 


### PR DESCRIPTION
###  Summary

Replaces request token verification with request signing.

See https://api.slack.com/docs/verifying-requests-from-slack for more info.

Fixes #33 

Tests are still in progress.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
