### PR TITLE
Add tests for error emitters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,10 +38,13 @@ def pytest_namespace():
         'create_signature': create_signature
     }
 
+@pytest.fixture
+def adapter():
+    return SlackEventAdapter("SIGNING_SECRET")
 
 @pytest.fixture
 def app():
-    adapter = SlackEventAdapter("SIGNING_SECRET")
-    app = adapter.server
+    events_adapter = adapter()
+    app = events_adapter.server
     app.testing = True
     return app

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,8 @@
 import time
 import pytest
 
+from slackeventsapi.server import SlackEventAdapterException
+
 def test_event_emission(adapter):
     test_event_emission.event_handled = False
 
@@ -29,3 +31,62 @@ def test_event_emission(adapter):
         assert res.status_code == 200
 
     assert test_event_emission.event_handled
+
+def test_error_timestamp(adapter):
+    test_error_timestamp.event_handled = False
+
+    # Error should trigger an event
+    @adapter.on('error')
+    def event_handler(exception):
+        test_error_timestamp.event_handled = True
+        assert isinstance(exception, SlackEventAdapterException)
+        assert str(exception) == 'Invalid request timestamp'
+
+    data = pytest.reaction_event_fixture
+
+    # Set timestamp to Thu Jan 01 00:00:00 1970 UTC (Epoch 0)
+    timestamp = 0
+
+    signature = pytest.create_signature(adapter.signing_secret, timestamp, data)
+
+    with adapter.server.test_client() as client:
+        res = client.post(
+            '/slack/events',
+            data=data,
+            content_type='application/json',
+            headers={
+                'X-Slack-Request-Timestamp': timestamp,
+                'X-Slack-Signature': signature
+            }
+        )
+        assert res.status_code == 403
+
+    assert test_error_timestamp.event_handled
+
+def test_error_signature(adapter):
+    test_error_signature.event_handled = False
+
+    # Error should trigger an event
+    @adapter.on('error')
+    def event_handler(exception):
+        test_error_signature.event_handled = True
+        assert isinstance(exception, SlackEventAdapterException)
+        assert str(exception) == 'Invalid request signature'
+
+    data = pytest.reaction_event_fixture
+    timestamp = int(time.time())
+    signature = pytest.create_signature('INVALID SIGNATURE', timestamp, data)
+
+    with adapter.server.test_client() as client:
+        res = client.post(
+            '/slack/events',
+            data=data,
+            content_type='application/json',
+            headers={
+                'X-Slack-Request-Timestamp': timestamp,
+                'X-Slack-Signature': signature
+            }
+        )
+        assert res.status_code == 403
+
+    assert test_error_signature.event_handled

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,27 +1,31 @@
 import time
 import pytest
-from slackeventsapi import SlackEventAdapter
 
-ADAPTER = SlackEventAdapter('SIGNING_SECRET')
+def test_event_emission(adapter):
+    test_event_emission.event_handled = False
 
-def test_event_emission(client):
     # Events should trigger an event
-    @ADAPTER.on('reaction_added')
-    def event_handler(event):
+    @adapter.on('reaction_added')
+    def event_handler(event_data):
+        test_event_emission.event_handled = True
+
+        event = event_data['event']
         assert event["reaction"] == 'grinning'
 
     data = pytest.reaction_event_fixture
     timestamp = int(time.time())
-    signature = pytest.create_signature(ADAPTER.signing_secret, timestamp, data)
+    signature = pytest.create_signature(adapter.signing_secret, timestamp, data)
 
-    res = client.post(
-        '/slack/events',
-        data=data,
-        content_type='application/json',
-        headers={
-            'X-Slack-Request-Timestamp': timestamp,
-            'X-Slack-Signature': signature
-        }
-    )
+    with adapter.server.test_client() as client:
+        res = client.post(
+            '/slack/events',
+            data=data,
+            content_type='application/json',
+            headers={
+                'X-Slack-Request-Timestamp': timestamp,
+                'X-Slack-Signature': signature
+            }
+        )
+        assert res.status_code == 200
 
-    assert res.status_code == 200
+    assert test_event_emission.event_handled


### PR DESCRIPTION
Test that emitters for timestamp and signature errors are emitted correctly.

Requires (and is based on) https://github.com/slackapi/python-slack-events-api/pull/37


* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).