### PR TITLE
Fix examples in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,8 +88,8 @@ Create a Slack Event Adapter for receiving actions via the Events API
 
   # Create an event listener for "reaction_added" events and print the emoji name
   @slack_events_adapter.on("reaction_added")
-  def reaction_added(event):
-    emoji = event.get("reaction")
+  def reaction_added(event_data):
+    emoji = event_data["event"]["reaction"]
     print(emoji)
 
 
@@ -123,8 +123,8 @@ Create a Slack Event Adapter for receiving actions via the Events API
 
   # Create an event listener for "reaction_added" events and print the emoji name
   @slack_events_adapter.on("reaction_added")
-  def reaction_added(event):
-    emoji = event.get("reaction")
+  def reaction_added(event_data):
+    emoji = event_data["event"]["reaction"]
     print(emoji)
 
 


### PR DESCRIPTION
###  Summary

The current examples always print `None`.
This PR will fix the problem.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
