### PR TITLE
Change example bot to work with slackclient>=2.0.

### DIFF
--- a/example/README.rst
+++ b/example/README.rst
@@ -3,7 +3,7 @@ Example Slack events API bot
 
 This example app shows how easy it is to implement the Slack Events API Adapter
 to receive Slack Events and respond to
-messages using Slack's Web API via python-slackclient.
+messages using Slack's Web API via python-slackclient v2.
 
 🤖  Setup and running the app
 ------------------------------

--- a/example/example.py
+++ b/example/example.py
@@ -1,5 +1,5 @@
 from slackeventsapi import SlackEventAdapter
-from slackclient import SlackClient
+import slack
 import os
 
 # Our app's Slack Event Adapter for receiving actions via the Events API
@@ -8,7 +8,7 @@ slack_events_adapter = SlackEventAdapter(slack_signing_secret, "/slack/events")
 
 # Create a SlackClient for your bot to use for Web API requests
 slack_bot_token = os.environ["SLACK_BOT_TOKEN"]
-slack_client = SlackClient(slack_bot_token)
+slack_client = slack.WebClient(slack_bot_token)
 
 # Example responder to greetings
 @slack_events_adapter.on("message")
@@ -18,7 +18,7 @@ def handle_message(event_data):
     if message.get("subtype") is None and "hi" in message.get('text'):
         channel = message["channel"]
         message = "Hello <@%s>! :tada:" % message["user"]
-        slack_client.api_call("chat.postMessage", channel=channel, text=message)
+        slack_client.chat_postMessage(channel=channel, text=message)
 
 
 # Example reaction emoji echo
@@ -28,7 +28,7 @@ def reaction_added(event_data):
     emoji = event["reaction"]
     channel = event["item"]["channel"]
     text = ":%s:" % emoji
-    slack_client.api_call("chat.postMessage", channel=channel, text=text)
+    slack_client.chat_postMessage(channel=channel, text=text)
 
 # Error events
 @slack_events_adapter.on("error")

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,2 +1,2 @@
-slackclient>=1.0.5
+slackclient>=2
 slackeventsapi>=0.1


### PR DESCRIPTION
###  Summary

Package slackclient  2.0 and beyond uses namespace `slack` in place of `slackclient`.
Use the equivalent `slack.WebClient`, and change the method call to use `slack.WebClient.chat_postMessage`. This is for the bot example code.

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
