### PR TITLE
Remove 2.7.6 from Tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 ; for quality analysis, use `tox -e flake8` or just `flake8 slackeventsapi`
 ; to build the docs, use `tox -e docs`
 envlist=
-    py{276,27,34,35,36},
+    py{27,34,35,36},
     flake8,
     docs
 


### PR DESCRIPTION
###  Summary

Travis is having issues running tests on 2.7.6 (in test.py, not this library), so I'm removing it from the test runner.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
