### PR TITLE
Accept usage of Flask Blueprints as app instance

### DIFF
--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, make_response
+from flask import Flask, request, make_response, Blueprint
 import json
 import platform
 import sys
@@ -18,7 +18,7 @@ class SlackServer(Flask):
         # If a server is passed in, bind the event handler routes to it,
         # otherwise create a new Flask instance.
         if server:
-            if isinstance(server, Flask):
+            if isinstance(server, Flask) or isinstance(server, Blueprint):
                 self.bind_route(server)
             else:
                 raise TypeError("Server must be an instance of Flask")

--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -21,7 +21,7 @@ class SlackServer(Flask):
             if isinstance(server, Flask) or isinstance(server, Blueprint):
                 self.bind_route(server)
             else:
-                raise TypeError("Server must be an instance of Flask")
+                raise TypeError("Server must be an instance of Flask or Blueprint")
         else:
             Flask.__init__(self, __name__)
             self.bind_route(self)


### PR DESCRIPTION
###  Summary

Allowing usage of slack blueprints to setup the SlackServer instance.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
