### PR TITLE
Fix #53 by removing python 2.7.6 from TravisCI builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ tests/.cache
 .cache
 .DS_Store
 .vscode/
+.eggs/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tests/.cache
 .coverage
 .cache
 .DS_Store
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-sudo: false
 dist: trusty
 language: python
 python:
-  - "2.7.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 coveralls==1.1
 ipdb==0.9.3
 ipython==4.1.2
-pdbpp==0.8.3
+pdbpp==0.10.2
 pytest>=3.2.0,<4.0.0
 pytest-flask==0.10.0
 pytest-mock>=1.6.3
@@ -9,3 +9,4 @@ pytest-cov==2.5.1
 pytest-pythonpath==0.7.1
 testfixtures==5.3.1
 tox==2.9.1
+werkzeug==0.16.1


### PR DESCRIPTION
###  Summary

This pull request fixed #53 by removing python 2.7.6 from CI builds.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
