### PR TITLE
Improve PyPI packaging & upgrade test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tests/.cache
 .vscode/
 .eggs/
 build/
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
-dist: trusty
+dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
-  - travis_retry pip install -r requirements.txt
-  - travis_retry pip install flake8
-  - travis_retry pip install -r requirements-dev.txt
+  - pip install -U pip pytest # python 2.7 requires pytest 4
+  - python setup.py install
+  - pip install flake8
+  - pip install -r requirements-dev.txt
 script:
   - flake8 slackeventsapi
-  - py.test --cov-report= --cov=slackeventsapi tests
+  - pytest --cov-report= --cov=slackeventsapi tests
 after_success:
   - codecov -e $TRAVIS_PYTHON_VERSION

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,8 @@
-coveralls==1.1
-ipdb==0.9.3
-ipython==4.1.2
-pdbpp==0.10.2
-pytest>=3.2.0,<4.0.0
-pytest-flask==0.10.0
-pytest-mock>=1.6.3
-pytest-cov==2.5.1
-pytest-pythonpath==0.7.1
-testfixtures==5.3.1
-tox==2.9.1
-werkzeug==0.16.1
+coveralls<2
+pytest<6 # python 2.7 requires pytest 4
+pytest-flask<2
+pytest-mock<2
+pytest-cov<3
+pytest-pythonpath<0.8
+testfixtures<7
+werkzeug<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-appdirs==1.4.0
-pyee==5.0.0
-flask==1.0
-packaging==16.8
-pyparsing==2.1.10
-six==1.10.0

--- a/run_clean_test.sh
+++ b/run_clean_test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+pip install -U pip && \
+pip freeze | xargs pip uninstall -y && \
+python setup.py install && \
+pip install -r requirements-dev.txt && \
+pytest tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[metadata]
-description-file = README.rst
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -20,34 +20,40 @@ def find_version(*file_paths):
                               version_file, re.M)
     if version_match:
         return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
+    raise RuntimeError('Unable to find version string.')
+
+with open("README.rst", "r") as fh:
+    long_description = fh.read()
 
 setup(name='slackeventsapi',
       version=find_version('slackeventsapi', 'version.py'),
-      description='Python Slack Events API adapter',
+      description='Python Slack Events API adapter for Flask',
       url='http://github.com/slackapi/python-slack-events-api',
       author='Slack Technologies, Inc.',
       author_email='opensource@slack.com',
       license='MIT',
       packages=['slackeventsapi'],
+      long_description_content_type='text/x-rst',
+      long_description=long_description,
       install_requires=[
-        'flask',
-        'pyee',
-        'requests',
-        'six',
+          'flask>=1,<2',
+          'pyee>=7,<8',
+          'itsdangerous<2', # for Python 2.7
+          'Jinja2<3', # for Python 2.7
+          'MarkupSafe<2', # for Python 2.7
       ],
       classifiers=[
-          "Development Status :: 5 - Production/Stable",
-          "Intended Audience :: Developers",
-          "Topic :: Communications :: Chat",
-          "Topic :: System :: Networking",
-          "Topic :: Office/Business",
-          "License :: OSI Approved :: MIT License",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.5",
-          "Programming Language :: Python :: 3.6",
-          "Programming Language :: Python :: 3.7",
-          "Programming Language :: Python :: 3.8",
+          'Development Status :: 5 - Production/Stable',
+          'Intended Audience :: Developers',
+          'Topic :: Communications :: Chat',
+          'Topic :: System :: Networking',
+          'Topic :: Office/Business',
+          'License :: OSI Approved :: MIT License',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
       ],
       zip_safe=False)

--- a/slackeventsapi/__init__.py
+++ b/slackeventsapi/__init__.py
@@ -1,12 +1,12 @@
-from pyee import EventEmitter
+from pyee import BaseEventEmitter
 from .server import SlackServer
 
 
-class SlackEventAdapter(EventEmitter):
+class SlackEventAdapter(BaseEventEmitter):
     # Initialize the Slack event server
     # If no endpoint is provided, default to listening on '/slack/events'
     def __init__(self, signing_secret, endpoint="/slack/events", server=None, **kwargs):
-        EventEmitter.__init__(self)
+        BaseEventEmitter.__init__(self)
         self.signing_secret = signing_secret
         self.server = SlackServer(signing_secret, endpoint, self, server, **kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,21 +30,18 @@ def event_with_bad_token():
     return json.dumps(event_data)
 
 
-def pytest_namespace():
-    return {
-        'reaction_event_fixture': load_event_fixture('reaction_added'),
-        'url_challenge_fixture': load_event_fixture('url_challenge'),
-        'bad_token_fixture': event_with_bad_token(),
-        'create_signature': create_signature
-    }
+def pytest_configure():
+    pytest.reaction_event_fixture = load_event_fixture('reaction_added')
+    pytest.url_challenge_fixture = load_event_fixture('url_challenge')
+    pytest.bad_token_fixture = event_with_bad_token()
+    pytest.create_signature = create_signature
 
 @pytest.fixture
 def adapter():
     return SlackEventAdapter("SIGNING_SECRET")
 
 @pytest.fixture
-def app():
-    events_adapter = adapter()
-    app = events_adapter.server
+def app(adapter):
+    app = adapter.server
     app.testing = True
     return app


### PR DESCRIPTION
###  Summary

This pull request cleans up the build and makes the packaging more specific about dependency versions. The following changes are done by this PR.

* Remove unnecessary `requests`, `six` from `install_requires`
* Do tests with `install_requires` settings and removed `requirements.txt`
* Migrate to `pyee` 7 (`EventEmitter` is deprecated)
* Migrate `pytest` to the latest in each Python version
* Add python 3.7, 3.8 to CI builds & remove unsupported 3.4
* Add the missing long description to PyPI package

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
