### PR TITLE
Fix #75 by checking the existence of request headers

### DIFF
--- a/slackeventsapi/server.py
+++ b/slackeventsapi/server.py
@@ -89,7 +89,7 @@ class SlackServer(Flask):
             # Each request comes with request timestamp and request signature
             # emit an error if the timestamp is out of range
             req_timestamp = request.headers.get('X-Slack-Request-Timestamp')
-            if abs(time() - int(req_timestamp)) > 60 * 5:
+            if req_timestamp is None or abs(time() - int(req_timestamp)) > 60 * 5:
                 slack_exception = SlackEventAdapterException('Invalid request timestamp')
                 self.emitter.emit('error', slack_exception)
                 return make_response("", 403)
@@ -97,7 +97,7 @@ class SlackServer(Flask):
             # Verify the request signature using the app's signing secret
             # emit an error if the signature can't be verified
             req_signature = request.headers.get('X-Slack-Signature')
-            if not self.verify_signature(req_timestamp, req_signature):
+            if req_signature is None or not self.verify_signature(req_timestamp, req_signature):
                 slack_exception = SlackEventAdapterException('Invalid request signature')
                 self.emitter.emit('error', slack_exception)
                 return make_response("", 403)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -56,6 +56,32 @@ def test_url_challenge(client):
     assert bytes.decode(res.data) == "valid_challenge_token"
 
 
+def test_no_request_timestamp_header(client):
+    data = pytest.reaction_event_fixture
+    with pytest.raises(SlackEventAdapterException) as excinfo:
+        res = client.post(
+            '/slack/events',
+            data=data,
+            content_type='application/json',
+            headers={}
+        )
+    assert str(excinfo.value) == 'Invalid request timestamp'
+
+def test_no_request_signature_header(client):
+    data = pytest.reaction_event_fixture
+    timestamp = int(time.time())
+    with pytest.raises(SlackEventAdapterException) as excinfo:
+        res = client.post(
+            '/slack/events',
+            data=data,
+            content_type='application/json',
+            headers={
+                'X-Slack-Request-Timestamp': timestamp, # valid
+            }
+        )
+    assert str(excinfo.value) == 'Invalid request signature'
+
+
 def test_invalid_request_signature(client):
     # Verify [package metadata header is set
     slack_adapter = SlackEventAdapter("SIGNING_SECRET")


### PR DESCRIPTION
###  Summary

This pull request fixes #75 by adding a simple logic to make sure if the x-slack-* headers are available in an incoming request. Such requests resulted in 50x errors. By applying this improvement, apps can properly reject those.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
