### PR TITLE
Added value check to init method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/.cache
 .eggs/
 build/
 .python-version
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tests/.cache
 build/
 .python-version
 venv/
+.venv/
+.env/

--- a/slackeventsapi/__init__.py
+++ b/slackeventsapi/__init__.py
@@ -7,11 +7,10 @@ class SlackEventAdapter(BaseEventEmitter):
     # If no endpoint is provided, default to listening on '/slack/events'
     def __init__(self, signing_secret, endpoint="/slack/events", server=None, **kwargs):
         BaseEventEmitter.__init__(self)
-        if signing_secret:
-            self.signing_secret = signing_secret
-        else:
-            raise ValueError(f'Got {type(signing_secret)} instead of the Slack signing secret token. Check the first '
-                             f'parameter.')
+        if signing_secret is None:
+            message = "signing_secret is required but you passed None in the first argument"
+            raise ValueError(message)
+        self.signing_secret = signing_secret
         self.server = SlackServer(signing_secret, endpoint, self, server, **kwargs)
 
     def start(self, host='127.0.0.1', port=None, debug=False, **kwargs):

--- a/slackeventsapi/__init__.py
+++ b/slackeventsapi/__init__.py
@@ -7,7 +7,11 @@ class SlackEventAdapter(BaseEventEmitter):
     # If no endpoint is provided, default to listening on '/slack/events'
     def __init__(self, signing_secret, endpoint="/slack/events", server=None, **kwargs):
         BaseEventEmitter.__init__(self)
-        self.signing_secret = signing_secret
+        if signing_secret:
+            self.signing_secret = signing_secret
+        else:
+            raise ValueError(f'Got {type(signing_secret)} instead of the Slack signing secret token. Check the first '
+                             f'parameter.')
         self.server = SlackServer(signing_secret, endpoint, self, server, **kwargs)
 
     def start(self, host='127.0.0.1', port=None, debug=False, **kwargs):


### PR DESCRIPTION
Added the value check to the init method.

###  Summary

I've set the env. variable for the Slack Event Token and used it to create Adapter as following:

```python
slack_event_adapter = SlackEventAdapter(os.environ.get("SLACK_EVENTS_TOKEN"), "/slack/events", app)
```

I made a typo while setting the variable, thus I was getting "Your URL didn't respond with the value of the challenge parameter." on the Event Subscription page with the following error in my terminal:

```bash
Traceback (most recent call last):
  File "D:\PycharmProjects\Slackbot\flipper\venv\lib\site-packages\flask\app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "D:\PycharmProjects\Slackbot\flipper\venv\lib\site-packages\flask\app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "D:\PycharmProjects\Slackbot\flipper\venv\lib\site-packages\flask\app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "D:\PycharmProjects\Slackbot\flipper\venv\lib\site-packages\flask\_compat.py", line 39, in reraise
    raise value
  File "D:\PycharmProjects\Slackbot\flipper\venv\lib\site-packages\flask\app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "D:\PycharmProjects\Slackbot\flipper\venv\lib\site-packages\flask\app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "D:\PycharmProjects\Slackbot\flipper\venv\lib\site-packages\slackeventsapi\server.py", line 100, in event
    if req_signature is None or not self.verify_signature(req_timestamp, req_signature):
  File "D:\PycharmProjects\Slackbot\flipper\venv\lib\site-packages\slackeventsapi\server.py", line 60, in verify_signature
    str.encode(self.signing_secret),
TypeError: descriptor 'encode' for 'str' objects doesn't apply to a 'NoneType' object
```

I took some time to look through the source code and see what went wrong. I think value checking could come in handy for other developers to easily find the error in their project.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
