### PR TITLE
chore(deps): specify max pyee version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='slackeventsapi',
       long_description=long_description,
       install_requires=[
           'flask>=2,<4',
-          'pyee>=8.<12',
+          'pyee>=8,<12',
       ],
       classifiers=[
           'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='slackeventsapi',
       long_description=long_description,
       install_requires=[
           'flask>=2,<4',
-          'pyee>=8',
+          'pyee>=8.<12',
       ],
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
###  Summary

Specify the maximum version of `pyee` allowed. This is to resolve the error `ImportError: cannot import name 'BaseEventEmitter' from 'pyee' (/venv/lib/python3.8/site-packages/pyee/__init__.py)` caused by the [latest release](https://github.com/jfhbrook/pyee/releases/tag/v12.0.0) of pyee.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
