### PR TITLE
ci: pin actions workflow step hashes and use minimum permissions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,7 +3,9 @@ name: CI Build
 
 on:
   push:
-    branches: [ main, v2 ]
+    branches:
+      - main
+      - v2
   pull_request:
 
 jobs:
@@ -13,25 +15,29 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install -U pip
-        pip install -e .
-        pip install -r requirements-dev.txt
-    - name: Run all tests
-      run: |
-        python_version=`python -V`
-        if [ ${python_version:7:3} == "3.12" ]; then
-          pip install -U flake8
-          flake8 slackeventsapi
-          pytest --cov-report= --cov=slackeventsapi tests && bash <(curl -s https://codecov.io/bash)
-        else
-          pytest tests
-        fi
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -e .
+          pip install -r requirements-dev.txt
+      - name: Run all tests
+        run: |
+          python_version=`python -V`
+          if [ ${python_version:7:3} == "3.12" ]; then
+            pip install -U flake8
+            flake8 slackeventsapi
+            pytest --cov-report= --cov=slackeventsapi tests && bash <(curl -s https://codecov.io/bash)
+          else
+            pytest tests
+          fi

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -4,20 +4,19 @@
 
 name: Close stale issues and PRs
 
-on: 
+on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0'
-  
-permissions:
-  issues: write
-  pull-requests: write
+    - cron: "0 0 * * 0"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/stale@v4.0.0
+      - uses: actions/stale@cdf15f641adb27a71842045a94023bef6945e3aa # v4.0.0
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 10
@@ -31,4 +30,3 @@ jobs:
           remove-stale-when-updated: true
           enable-statistics: true
           operations-per-run: 60
-


### PR DESCRIPTION
### Summary

This PR uses the wonderful [`zizmor`](https://github.com/zizmorcore/zizmor) tool to audit our own workflows and [`pinact`](https://github.com/suzuki-shunsuke/pinact) for pinned versioning 👾 

### Reviewers

A similar audit can be performed with the `zizmor` tool:

```sh
$ zizmor .
...
No findings to report. Good job! (2 suppressed)
```

> The suppressed findings are expected permission blocks at the top-level of a workflow, but we set this for each job.
### Requirements

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
