### PR TITLE
build: replace support of python '3.6' with python '3.13'

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,35 +3,43 @@ name: CI Build
 
 on:
   push:
-    branches: [ main, v2 ]
+    branches:
+      - main
+      - v2
   pull_request:
 
 jobs:
   build:
-    # Avoiding -latest due to https://github.com/actions/setup-python/issues/162
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version:
+          - "3.13"
+          - "3.12"
+          - "3.11"
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install -U pip
-        pip install -e .
-        pip install -r requirements-dev.txt
-    - name: Run all tests
-      run: |
-        python_version=`python -V`
-        if [ ${python_version:7:3} == "3.12" ]; then
-          pip install -U flake8
-          flake8 slackeventsapi
-          pytest --cov-report= --cov=slackeventsapi tests && bash <(curl -s https://codecov.io/bash)
-        else
-          pytest tests
-        fi
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -e .
+          pip install -r requirements-dev.txt
+      - name: Run all tests
+        run: |
+          python_version=`python -V`
+          if [ ${python_version:7:3} == "3.12" ]; then
+            pip install -U flake8
+            flake8 slackeventsapi
+            pytest --cov-report= --cov=slackeventsapi tests && bash <(curl -s https://codecov.io/bash)
+          else
+            pytest tests
+          fi

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     strategy:
       matrix:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from setuptools import setup
 import os
 import re
+
+from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -30,7 +31,7 @@ setup(name='slackeventsapi',
       author_email='opensource@slack.com',
       license='MIT',
       packages=['slackeventsapi'],
-      python_requires=">=3.6",
+      python_requires=">=3.7",
       long_description_content_type='text/x-rst',
       long_description=long_description,
       install_requires=[
@@ -45,12 +46,12 @@ setup(name='slackeventsapi',
           'Topic :: Office/Business',
           'License :: OSI Approved :: MIT License',
           'Programming Language :: Python',
-          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: 3.11',
           'Programming Language :: Python :: 3.12',
+          'Programming Language :: Python :: 3.13',
       ],
       zip_safe=False)


### PR DESCRIPTION
### Summary

This PR drops support of Python 3.6 and adds support for Python 3.13.

### Notes

- 📚 https://slack.dev/python-development-at-slack/
- 🔍 Found in CI failures of: #110 

### Requirements

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/python-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
